### PR TITLE
Adds pyproject.toml to fix build without numpy previously installed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst CHANGES.rst Makefile .travis.yml common.mk rules.mk theory.options mocks.options FAQ INSTALL LICENSE
+include README.rst CHANGES.rst Makefile .travis.yml common.mk rules.mk theory.options mocks.options FAQ INSTALL LICENSE pyproject.toml
 include theory/python_bindings/call_correlation_functions.py mocks/python_bindings/call_correlation_functions_mocks.py
 
 include           docs               Makefile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=40.6.0",
+    "wheel",
+    "numpy",
+]


### PR DESCRIPTION
It seems like specifying numpy as a dependency here is sufficient to get the build working for me. After adding this, I can install using:

```bash
conda create -c conda-forge -n suave python gsl
conda activate suave
pip install .
```

and this should also work with `pip install suave` once this file is included in the published version.